### PR TITLE
[nbcleanmeta gha] correct call to nbcleanmeta

### DIFF
--- a/workflow-templates/nbcleanmeta.yml
+++ b/workflow-templates/nbcleanmeta.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git diff --name-only --diff-filter AM "origin/${{ github.event.repository.default_branch }}" | sed 's/^/"/g' | sed 's/$/"/g' | tr '\n' ' ' | nbcleanmeta run
+          git diff --name-only --diff-filter AM "origin/${{ github.event.repository.default_branch }}" | sed 's/^/"/g' | sed 's/$/"/g' | tr '\n' ' ' | xargs nbcleanmeta run
           if ! git diff --exit-code; then
             git add .
             git commit -m "clean notebooks metadata"


### PR DESCRIPTION
correct the call so that only the files modified by a commit are handled by nbcleanmeta

addresses https://github.com/lewagon/utils/issues/67

this is tested by https://github.com/lewagon/data-solutions/pull/829